### PR TITLE
use Module#prepend instead of alias_method_chain

### DIFF
--- a/lib/activerecord/mysql/reconnect/abstract_mysql_adapter_ext.rb
+++ b/lib/activerecord/mysql/reconnect/abstract_mysql_adapter_ext.rb
@@ -1,17 +1,19 @@
-class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
-  def execute_with_reconnect(sql, name = nil)
+module ExecuteWithReconnect
+  def execute(sql, name = nil)
     retryable(sql, name) do |sql_names|
       retval = nil
 
       sql_names.each do |s, n|
-        retval = execute_without_reconnect(s, n)
+        retval = super(s, n)
       end
 
       retval
     end
   end
+end
 
-  alias_method_chain :execute, :reconnect
+class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+  prepend ExecuteWithReconnect
 
   private
 

--- a/lib/activerecord/mysql/reconnect/connection_pool_ext.rb
+++ b/lib/activerecord/mysql/reconnect/connection_pool_ext.rb
@@ -1,12 +1,11 @@
-class ActiveRecord::ConnectionAdapters::ConnectionPool
-  def new_connection_with_retry
+module NewConnectionWithRetry
+  def new_connection
     Activerecord::Mysql::Reconnect.retryable(
-      :proc => proc {
-        new_connection_without_retry
-      },
+      :proc => proc { super },
       :connection => spec.config,
     )
   end
-
-  alias_method_chain :new_connection, :retry
+end
+class ActiveRecord::ConnectionAdapters::ConnectionPool
+  prepend NewConnectionWithRetry
 end

--- a/lib/activerecord/mysql/reconnect/mysql2_adapter_ext.rb
+++ b/lib/activerecord/mysql/reconnect/mysql2_adapter_ext.rb
@@ -1,12 +1,13 @@
-class ActiveRecord::ConnectionAdapters::Mysql2Adapter
-  def reconnect_with_retry!
+module ReconnectWithRetry
+  def reconnect!
     Activerecord::Mysql::Reconnect.retryable(
-      :proc => proc {
-        reconnect_without_retry!
-      },
+      :proc => proc { super },
       :connection => @connection
     )
   end
+end
 
-  alias_method_chain :reconnect!, :retry
+class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+  alias_method :reconnect_without_retry!, :reconnect!
+  prepend ReconnectWithRetry
 end


### PR DESCRIPTION
alias_method_chain is deprecated on Rails 5.
So I wrote patch that use Module#prepend instead of alias_method_chain.