### PR TITLE
Added "Connection was killed" as an error string to reconnect on.

### DIFF
--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -45,6 +45,7 @@ module Activerecord::Mysql::Reconnect
     'Unknown MySQL server host', # For DNS blips
     "Lost connection to MySQL server at 'reading initial communication packet'",
     "MySQL client is not connected",
+    'Connection was killed',
   ]
 
   HANDLE_ERROR_MESSAGES = HANDLE_R_ERROR_MESSAGES + HANDLE_RW_ERROR_MESSAGES


### PR DESCRIPTION
![connection_was_killed](https://user-images.githubusercontent.com/382216/35752914-4087564a-0823-11e8-90cc-7eee20a7cc8f.gif)


I'm working on migrating to a [MariaDB cluster ](https://mariadb.com/kb/en/library/what-is-mariadb-galera-cluster/) and need to be able to retry queries when a database node gets rebooted etc.  In our case `Mysql2::Error: Connection was killed` is the error in that situation.  That's the same as just turning off your DB server temporarily as I do in the above screen recording. 


Before the change we'd get this: (gently sanitized data)

```
IMPORT HRS PHONES
PHONE NOT SAVED [HRS] - Mysql2::Error: Connection was killed: SELECT  `phones`.* FROM `phones` WHERE `phones`.`person_id` = 20606 AND `phones`.`phone_number` = '5555555967' AND `phones`.`phone_type` = 'Home' LIMIT 1
Mysql2::Error: Connection was killed: SELECT  `phones`.* FROM `phones` WHERE `phones`.`person_id` = 20606 AND `phones`.`phone_number` = '5555555967' AND `phones`.`phone_type` = 'Home' LIMIT 1
[Fail] 00:00:44 Import: HRS Phones Mysql2::Error: Connection was killed: UPDATE `people` SET `encrypted_ssn` = '/zbazE4KgvgcxXS4fJyIjLHXP5WnHyQkIA==\n', `encrypted_ssn_iv` = 'bDw3W64MvZa1pmNq\n', `encrypted_gender` = 'U5gQ7BiV7eq1pCo2e9veVqc7RyFVww==\n', `encrypted_gender_iv` = 'NX6jb1S92I+mhN2s\n', `updated_at` = '2018-02-02 19:55:39' WHERE `people`.`id` = 14677
[Fail] 00:00:44 Import: HRS Phones Mysql2::Error: Connection was killed: UPDATE `people` SET `encrypted_ssn` = '/zbazE4KgvgcxXS4fJyIjLHXP5WnHyQkIA==\n', `encrypted_ssn_iv` = 'bDw3W64MvZa1pmNq\n', `encrypted_gender` = 'U5gQ7BiV7eq1pCo2e9veVqc7RyFVww==\n', `encrypted_gender_iv` = 'NX6jb1S92I+mhN2s\n', `updated_at` = '2018-02-02 19:55:39' WHERE `people`.`id` = 14677