### PR TITLE
Add error string 'SSL connection error: protocol version mismatch'

### DIFF
--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -46,6 +46,7 @@ module Activerecord::Mysql::Reconnect
     "Lost connection to MySQL server at 'reading initial communication packet'",
     "MySQL client is not connected",
     'Connection was killed',
+    'SSL connection error: protocol version mismatch' # can indicate an error opening an SSL connection which works on retry
   ]
 
   HANDLE_ERROR_MESSAGES = HANDLE_R_ERROR_MESSAGES + HANDLE_RW_ERROR_MESSAGES

--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -47,6 +47,7 @@ module Activerecord::Mysql::Reconnect
     "MySQL client is not connected",
     'Connection was killed',
     'SSL connection error: protocol version mismatch' # can indicate an error opening an SSL connection which works on retry
+    'Errno::' # broadly cover any case where Errno is set
   ]
 
   HANDLE_ERROR_MESSAGES = HANDLE_R_ERROR_MESSAGES + HANDLE_RW_ERROR_MESSAGES

--- a/lib/activerecord/mysql/reconnect.rb
+++ b/lib/activerecord/mysql/reconnect.rb
@@ -46,7 +46,7 @@ module Activerecord::Mysql::Reconnect
     "Lost connection to MySQL server at 'reading initial communication packet'",
     "MySQL client is not connected",
     'Connection was killed',
-    'SSL connection error: protocol version mismatch' # can indicate an error opening an SSL connection which works on retry
+    'SSL connection error: protocol version mismatch', # can indicate an error opening an SSL connection which works on retry
     'Errno::' # broadly cover any case where Errno is set
   ]
 


### PR DESCRIPTION
We see this in production on Amazon RDS, and it does work on retry.  I assume this indicates an error opening an SSL connection.